### PR TITLE
Add PA TIC links

### DIFF
--- a/price_transparency/insurers/machine_readable_homepages.csv
+++ b/price_transparency/insurers/machine_readable_homepages.csv
@@ -4,11 +4,16 @@ id,insurer_name_legal,insurer_name_common,price_transparency_url,price_transpare
 3,Blue Cross Blue Shield of North Carolina,Blue Cross Blue Shield of North Carolina,https://www.bluecrossnc.com/about-us/policies-and-best-practices/transparency-coverage-mrf,up,https://pstage.bluecrossnc.com/about-us/policies-and-best-practices/transparency-coverage-mrf,2022-09-12
 4,Humana Inc.,Humana,https://developers.humana.com/Cost-Transparency,up,,2022-09-12
 5,Anthem Inc.,Anthem,https://www.anthem.com/machine-readable-file/search/,up,,2022-09-12
-6,Centene Corporation,Ambetter,https://www.centene.com/price-transparency-files.html,up,,2022-09-12
+6,Centene Corporation,Ambetter,https://www.centene.com/price-transparency-files.html,up,,2023-11-05
 7,Health Care Service Corporation,HCSC,https://www.hcsc.com/who-we-are/regulatory-disclosures,up,,2022-09-12
 8,Kaiser Permanente,Kaiser Permanente,https://healthy.kaiserpermanente.org/front-door/machine-readable,up,https://healthy.kaiserpermanente.org/pages/technical-information,2022-09-12
 9,PacificSource Health Plans,PacificSource,https://pacificsource.com/resources/json-files,up,,2022-09-12
 10,Blue Cross Blue Shield of Massachusetts,Blue Cross Blue Shield of Massachusetts,https://transparency-in-coverage.bluecrossma.com/,up,,2022-09-12
 11,University of Pittsburgh Medical Center,UPMC Health Plan,https://www.upmchealthplan.com/transparency-in-coverage/mrf/,up,,2022-09-12
-12,,Geisinger Health Plan,https://www.geisinger.org/health-plan/nosurprisesact,up,,2022-09-12
+12,,Geisinger Health Plan,https://www.geisinger.org/health-plan/nosurprisesact,up,,2023-11-05
 13,Aetna Life Insurance Company,Aetna,https://www.aetna.com/individuals-families/member-rights-resources/rights/disclosure-information.html,up,,2022-09-12
+14,,Community Health Partners,https://www.healthpartners.com/hp/legal-notices/disclosures/transparency/index.html,up,,2023-11-05
+15,,Capital Blue Cross,https://capitalbluecross.healthsparq.com/healthsparq/public/#/one/insurerCode=CAPBC_I&brandCode=CAPBC&productCode=MRF,up,,2023-11-05
+16,Highmark,Highmark,https://mrfdata.hmhs.com/,up,,2023-11-05
+17,Independence Blue Cross,Independence Blue Cross,https://www.ibx.com/developer-resources,up,,2023-11-05
+18,Oscar Health,Oscar,https://www.hioscar.com/transparency-in-coverage-files/oscar,up,,2023-11-05


### PR DESCRIPTION
# Type of change

<!-- Please check the applicable boxes below by entering [x] (with no spaces) for each applicable entry. 

You may leave this block commented, or remove it.
-->

- [ ] Documentation update.
- [x] Data submission.
- [ ] A different type of contribution.


# Summary

<!-- Please include a summary of the changes included in this pull request below.

You may leave this block commented, or remove it. -->
This adds a few TIC homepages in PA; links acquired and verified from the recent PA DOI [report](https://www.insurance.pa.gov/Coverage/Documents/ACA-Plan-Transparency-Reports/TransparencyCoverageReport-ACAHealthPlans2023.pdf).

# Checklist

<!-- Please check both boxes below by entering [x] (with no spaces), to indicate you're following the contribution guidelines.

You may leave this block commented, or remove it. -->

- [x] I've read the contribution guidelines.
- [x] I've verified this PR does not duplicate existing or ongoing work, via existing issues and discussion.